### PR TITLE
Updated link to py-substrate-interface docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 - [OpenBrush](https://openbrush.io/): OpenBrush is a library for smart contract development with ink!.
 - [PSP-22](https://github.com/w3f/PSPs/blob/master/PSPs/psp-22.md): Fungible Token Standard for Substrate's `contracts` pallet.
-- [py-substrate-interface](https://github.com/polkascan/py-substrate-interface/#ink-contract-interfacing): Library by Polkascan to interact with ink! contracts from Python.
+- [py-substrate-interface](https://polkascan.github.io/py-substrate-interface/usage/ink-contract-interfacing/): Library by Polkascan to interact with ink! contracts from Python.
 - [hashes](https://github.com/RustCrypto/hashes): Collection of cryptographic hash functions written in pure Rust. (`no_std` needs to be enabled).
 - [data-encoding](https://github.com/ia0/data-encoding): Efficient and customizable data-encoding functions in Rust. (`no_std` needs to be enabled).
 - [`useInkathon`](https://github.com/scio-labs/use-inkathon) - Typesafe React Hooks library abstracting functionality by polkadot.js for working with Substrate-based networks and ink! smart contracts maintained by [Scio Labs](https://scio.xyz).


### PR DESCRIPTION
Updated link to new documentation URL: https://polkascan.github.io/py-substrate-interface/usage/ink-contract-interfacing/